### PR TITLE
Fix crashes during import

### DIFF
--- a/VersionManager/Extraction/PackageExtractor.cs
+++ b/VersionManager/Extraction/PackageExtractor.cs
@@ -30,7 +30,7 @@ namespace VersionManager.Extraction
                         string dir = entityToDir(ent);
                         if (!cache.CacheDirectory(dir))
                         {
-                            entry.ExtractToFile(Path.Combine(dir, ent.Name), false);
+                            entry.ExtractToFile(Path.Combine(dir, ent.Name), true);
                         }
                         progress?.Report(1);
                     }

--- a/VersionManagerUI/Pages/Replays.xaml.cs
+++ b/VersionManagerUI/Pages/Replays.xaml.cs
@@ -103,6 +103,10 @@ namespace VersionManagerUI.Pages
 
         private void UpdateReplayPlayable()
         {
+            if (_selectedReplay == null)
+            {
+                return;
+            }
             btnPlay.IsEnabled = false;
             if (_selectedReplay.Version != GameVersion.UNKNOWN)
             {


### PR DESCRIPTION
If the application is terminated during importing and started again, importing will crash due to unhandled file colisions.
Another crash might occur if no replay is selected and a new version is imported.
This patch fixes both.